### PR TITLE
Migration from Perforce - Digital Ocean

### DIFF
--- a/Source/Cyber/Core/CyberCharacter.cpp
+++ b/Source/Cyber/Core/CyberCharacter.cpp
@@ -209,6 +209,8 @@ void ACyberCharacter::PossessedBy(AController* NewController)
 {
 	Super::PossessedBy(NewController);
 
+	BindSaveGameDelegatesInPlayerState();
+
 	SetupMaterialColors();
 
 	SetupGameplayAbilitySystemComponent();
@@ -221,6 +223,12 @@ void ACyberCharacter::PossessedBy(AController* NewController)
 
 	//Add Input Mapping Context
 	AddMappingContextCharacter(NewController);
+
+	if (UCyberGameInstance* CyberGameInstance = Cast<UCyberGameInstance>(GetGameInstance()))
+	{
+		CyberGameInstance->OnGameLoaded.AddDynamic(this, &ThisClass::OnGameLoadedEvent);
+		CyberGameInstance->OnGameSaved.AddDynamic(this, &ThisClass::OnGameSavedEvent);
+	}
 }
 
 void ACyberCharacter::AddMappingContextCharacter(AController* newController)
@@ -252,13 +260,12 @@ void ACyberCharacter::OnRep_PlayerState()
 	else
 	{
 		// On the ocasion the Player Controller replicates after the Player State to fix the Controller reference inside the Ability System.
-
 		GASAbilitySystemComponent->RefreshAbilityActorInfo();
 	}
 
 	SetupMaterialColors();
 
-	// 
+	// Alert Game State that a player joined.
 	if (ACyberGameState* CyberGameState = Cast<ACyberGameState>(UGameplayStatics::GetGameState(GetWorld())))
 	{
 		CyberGameState->PlayerJoined();
@@ -631,6 +638,14 @@ void ACyberCharacter::OnGameSavedEvent()
 	// Event just in case it is needed.
 }
 
+void ACyberCharacter::BindSaveGameDelegatesInPlayerState()
+{
+	if (ACyberPlayerState* CyberPlayerState = GetPlayerState<ACyberPlayerState>())
+	{
+		CyberPlayerState->BindSaveLoadGameDelegates();
+	}
+}
+
 void ACyberCharacter::BeginPlay()
 {
 	// Call the base class  
@@ -638,12 +653,6 @@ void ACyberCharacter::BeginPlay()
 
 	//Add Input Mapping Context
 	AddMappingContextCharacter(Controller);
-
-	if (UCyberGameInstance* CyberGameInstance = Cast<UCyberGameInstance>(GetGameInstance()))
-	{
-		CyberGameInstance->OnGameLoaded.AddDynamic(this, &ThisClass::OnGameLoadedEvent);
-		CyberGameInstance->OnGameSaved.AddDynamic(this, &ThisClass::OnGameSavedEvent);
-	}
 }
 
 void ACyberCharacter::Tick(float DeltaTime)

--- a/Source/Cyber/Core/CyberCharacter.h
+++ b/Source/Cyber/Core/CyberCharacter.h
@@ -371,6 +371,8 @@ public:
 	UFUNCTION()
 	void OnGameSavedEvent();
 
+	void BindSaveGameDelegatesInPlayerState();
+
 
 protected:
 	// APawn interface

--- a/Source/Cyber/Core/CyberGameInstance.cpp
+++ b/Source/Cyber/Core/CyberGameInstance.cpp
@@ -8,6 +8,7 @@
 #include "..\Interfaces/Saveable.h"
 #include "OnlineSubsystem.h"
 #include "Interfaces/OnlineIdentityInterface.h"
+#include "..\CyberSessionSubsystem.h"
 
 void UCyberGameInstance::CreateSaveGame()
 {
@@ -61,13 +62,15 @@ void UCyberGameInstance::OnLoginCompleted(int NumberOfPlayers, bool WasSuccessfu
 
 void UCyberGameInstance::SaveGame(bool Async)
 {
+	FString NewSlotName = GetSlotName(IsLocalMatch());
+
 	if (Async)
 	{
-		UGameplayStatics::AsyncSaveGameToSlot(CyberSaveGame, SlotName, UserIndex, FAsyncSaveGameToSlotDelegate::CreateUObject(this, &ThisClass::OnAsyncSaveGameToSlot));
+		UGameplayStatics::AsyncSaveGameToSlot(CyberSaveGame, NewSlotName, UserIndex, FAsyncSaveGameToSlotDelegate::CreateUObject(this, &ThisClass::OnAsyncSaveGameToSlot));
 	}
 	else
 	{
-		if (UGameplayStatics::SaveGameToSlot(CyberSaveGame, SlotName, UserIndex))
+		if (UGameplayStatics::SaveGameToSlot(CyberSaveGame, NewSlotName, UserIndex))
 		{
 			OnGameSaved.Broadcast();
 		}
@@ -83,17 +86,40 @@ void UCyberGameInstance::OnAsyncSaveGameToSlot(const FString& slotName, const in
 	}
 }
 
+bool UCyberGameInstance::IsLocalMatch()
+{
+	return GetSubsystem<UCyberSessionSubsystem>()->bIsLocalMatch;
+}
+
+FString UCyberGameInstance::GetSlotName(bool bIsLocalMatch)
+{
+	FString newSlotName = TEXT("ERROR");
+
+	if (bIsLocalMatch)
+	{
+		newSlotName = LocalMultiplayerSlot;
+	}
+	else
+	{
+		newSlotName = SlotName;
+	}
+
+	return newSlotName;
+}
+
 void UCyberGameInstance::LoadGame(bool Async)
 {
-	if (UGameplayStatics::DoesSaveGameExist(SlotName, UserIndex))
+	FString NewSlotName = GetSlotName(IsLocalMatch());
+
+	if (UGameplayStatics::DoesSaveGameExist(NewSlotName, UserIndex))
 	{
 		if (Async)
 		{
-			UGameplayStatics::AsyncLoadGameFromSlot(SlotName, UserIndex, FAsyncLoadGameFromSlotDelegate::CreateUObject(this, &ThisClass::OnAsyncLoadGameFromSlot));
+			UGameplayStatics::AsyncLoadGameFromSlot(NewSlotName, UserIndex, FAsyncLoadGameFromSlotDelegate::CreateUObject(this, &ThisClass::OnAsyncLoadGameFromSlot));
 		}
 		else
 		{
-			if (UCyberSaveGame* saveGameReference = Cast<UCyberSaveGame>(UGameplayStatics::LoadGameFromSlot(SlotName, UserIndex)))
+			if (UCyberSaveGame* saveGameReference = Cast<UCyberSaveGame>(UGameplayStatics::LoadGameFromSlot(NewSlotName, UserIndex)))
 			{
 				CyberSaveGame = saveGameReference;
 

--- a/Source/Cyber/Core/CyberGameInstance.h
+++ b/Source/Cyber/Core/CyberGameInstance.h
@@ -63,11 +63,17 @@ public:
 
 	UFUNCTION(BlueprintCallable)
 	void CreateSaveGame();
-
+	 
 	void OnAsyncLoadGameFromSlot(const FString& slotName, const int32 userIndex, USaveGame* saveGameRef);
 
 	void OnAsyncSaveGameToSlot(const FString& slotName, const int32 userIndex, bool Success);
 
+	/* Cyber Session Subsystem */
+	UFUNCTION(BlueprintCallable)
+	bool IsLocalMatch();
+
+	/* Get Slot Name */
+	FString GetSlotName(bool bIsLocalMatch);
 
 protected:
 
@@ -75,6 +81,8 @@ protected:
 	TObjectPtr<UCyberSaveGame> CyberSaveGame = nullptr;
 
 	const FString SlotName = TEXT("Slot_01");
+
+	const FString LocalMultiplayerSlot = TEXT("Slot_LocalMatch_01");
 
 	const int32 UserIndex = 0;
 

--- a/Source/Cyber/Core/CyberGameMode.cpp
+++ b/Source/Cyber/Core/CyberGameMode.cpp
@@ -1,6 +1,9 @@
 #include "CyberGameMode.h"
 #include "CyberGameState.h"
 #include "Kismet/GameplayStatics.h"
+#include "CyberPlayerController.h"
+#include "CyberPlayerState.h"
+#include "CyberGameState.h"
 
 void ACyberGameMode::SetColorsIndex(int32 newColorsIndex)
 {
@@ -20,6 +23,34 @@ void ACyberGameMode::PostLogin(APlayerController* NewPlayer)
 	{
 		CyberGameState->PlayerJoined();
 	}
+}
+
+TSubclassOf<UUserWidget> ACyberGameMode::GetLocalPlayerWidgetClass(AController* controller)
+{
+	APlayerState* PlayerState = controller->GetPlayerState<APlayerState>();
+
+	if (!PlayerState)
+	{
+		return nullptr;
+	}
+
+	if (GetWorld()->GetGameState())
+	{
+		for (int32 i = 0; i < GetWorld()->GetGameState()->PlayerArray.Num(); i++)
+		{
+			if (PlayerState == GetWorld()->GetGameState()->PlayerArray[i])
+			{
+				return LocalPlayerInfoWidgetClasses[i%2];
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+TSubclassOf<UUserWidget> ACyberGameMode::GetSharedInfoWidgetClass()
+{
+	return SharedInfoWidgetClass;
 }
 
 void ACyberGameMode::StartPlay()

--- a/Source/Cyber/Core/CyberGameMode.h
+++ b/Source/Cyber/Core/CyberGameMode.h
@@ -5,6 +5,8 @@
 #include "..\Enemy\CyberEnemySpawner.h"
 #include "CyberGameMode.generated.h"
 
+class ACyberPlayerController;
+
 UCLASS()
 class CYBER_API ACyberGameMode : public AGameMode
 {
@@ -22,7 +24,21 @@ public:
 	void ActivateEnemySpawner();
 
 	ACyberEnemySpawner* EnemySpawner = nullptr;
-	
+
+	/* Local Multiplayer Widgets */
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Widget | Local Multiplayer")
+	TArray<TSubclassOf<UUserWidget>> LocalPlayerInfoWidgetClasses;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Widget | Local Multiplayer")
+	TSubclassOf<UUserWidget> SharedInfoWidgetClass;
+
+	UFUNCTION(BlueprintCallable)
+	TSubclassOf<UUserWidget> GetLocalPlayerWidgetClass(AController* controller);
+
+	UFUNCTION(BlueprintCallable)
+	TSubclassOf<UUserWidget> GetSharedInfoWidgetClass();
+
 protected:
 
 	int32 ColorsIndex = 0;
@@ -30,4 +46,7 @@ protected:
 	virtual void StartPlay() override;
 
 	ACyberEnemySpawner* FindEnemySpawner();
+
+	int32 PlayerIndex = 0;
+
 };

--- a/Source/Cyber/Core/CyberPlayerController.cpp
+++ b/Source/Cyber/Core/CyberPlayerController.cpp
@@ -8,6 +8,9 @@
 #include "Blueprint/WidgetLayoutLibrary.h"
 #include "CyberGameState.h"
 #include "Kismet/GameplayStatics.h"
+#include "..\CyberSessionSubsystem.h"
+#include "CyberGameInstance.h"
+#include "CyberGameMode.h"
 
 ACyberPlayerController::ACyberPlayerController()
 {
@@ -71,7 +74,7 @@ void ACyberPlayerController::ShowPreGameTimer()
 			if (!PreGameTimerWidget)
 			{
 				PreGameTimerWidget = CreateWidget(this, PreGameTimerWidgetClass);
-				PreGameTimerWidget->AddToPlayerScreen();
+				PreGameTimerWidget->AddToViewport();
 
 				SetIgnoreMoveInput(true);
 			}
@@ -102,19 +105,63 @@ void ACyberPlayerController::ShowPlayerInfo()
 {
 	if (IsLocalController())
 	{
-		if (PlayerInfoWidgetClass)
+		UCyberGameInstance* CyberGameInstance = Cast<UCyberGameInstance>(GetGameInstance());
+
+		if (!CyberGameInstance)
 		{
-			if(!PlayerInfoWidget)
+			return;
+		}
+
+		if (!CyberGameInstance->IsLocalMatch())
+		{
+			// Is Online Match
+			if (OnlinePlayerInfoWidgetClass)
 			{
-				PlayerInfoWidget = CreateWidget(this, PlayerInfoWidgetClass);
-				PlayerInfoWidget->AddToPlayerScreen();
+				if (!OnlinePlayerInfoWidget)
+				{
+					OnlinePlayerInfoWidget = CreateWidget(this, OnlinePlayerInfoWidgetClass);
+					OnlinePlayerInfoWidget->AddToPlayerScreen();
+				}
+			}
+		}
+		else // Is Local Match
+		{
+			ACyberGameMode* CyberGameMode = Cast<ACyberGameMode>(UGameplayStatics::GetGameMode(GetWorld()));
+
+			if (!CyberGameMode)
+			{
+				return;
 			}
 
-			SetInputMode(FInputModeGameOnly());
-			SetShowMouseCursor(false);
-			
-			ResetIgnoreMoveInput();
+			TSubclassOf<UUserWidget> LocalPlayerInfoWidgetClass = CyberGameMode->GetLocalPlayerWidgetClass(this);
+
+			// Is Local Match
+			if (LocalPlayerInfoWidgetClass)
+			{
+				if (!LocalPlayerInfoWidget)
+				{
+					LocalPlayerInfoWidget = CreateWidget(this, LocalPlayerInfoWidgetClass);
+					LocalPlayerInfoWidget->AddToPlayerScreen();
+				}
+			}
+
+			if (CyberGameMode->GetSharedInfoWidgetClass())
+			{
+				if(GetLocalPlayer()->IsPrimaryPlayer())
+				{
+					if (!SharedInfoWidget)
+					{
+						SharedInfoWidget = CreateWidget(this, CyberGameMode->GetSharedInfoWidgetClass());
+						SharedInfoWidget->AddToViewport();
+					}
+				}
+			}
 		}
+
+		SetInputMode(FInputModeGameOnly());
+		SetShowMouseCursor(false);
+
+		ResetIgnoreMoveInput();
 	}
 }
 
@@ -125,31 +172,66 @@ void ACyberPlayerController::RemovePlayerInfo()
 		return;
 	}
 
-	if (!PlayerInfoWidget)
+	if (!OnlinePlayerInfoWidget && !SharedInfoWidget)
 	{
 		return;
 	}
 
-	if (PlayerInfoWidget->IsInViewport())
+	if(OnlinePlayerInfoWidget)
 	{
-		PlayerInfoWidget->RemoveFromParent();
-		PlayerInfoWidget = nullptr;
+		if (OnlinePlayerInfoWidget->IsInViewport()) // Online Match
+		{
+			OnlinePlayerInfoWidget->RemoveFromParent();
+			OnlinePlayerInfoWidget = nullptr;
+		}
 	}
+	else if(SharedInfoWidget)
+	{
+		if (SharedInfoWidget->IsInViewport()) // Local Match
+		{
+			SharedInfoWidget->RemoveFromParent();
+			SharedInfoWidget = nullptr;
 
+			if(LocalPlayerInfoWidget)
+			{
+				LocalPlayerInfoWidget->RemoveFromParent();
+				LocalPlayerInfoWidget = nullptr;
+			}
+		}
+	}
 }
 
 void ACyberPlayerController::ShowGameOverScreen()
 {
 	if (IsLocalController())
 	{
-		if (GameOverWidgetClass && PlayerInfoWidget)
+		if (GameOverWidgetClass)
 		{
-			if (PlayerInfoWidget->IsInViewport())
+			if(OnlinePlayerInfoWidget)
 			{
-				PlayerInfoWidget->RemoveFromParent();
-				PlayerInfoWidget = nullptr;
+				if (OnlinePlayerInfoWidget->IsInViewport()) // Online Match
+				{
+					OnlinePlayerInfoWidget->RemoveFromParent();
+					OnlinePlayerInfoWidget = nullptr;
+				}
+			}
+			else if (LocalPlayerInfoWidget) // Local Match
+			{
+				// Remove Widget which belongs only to Player
+				LocalPlayerInfoWidget->RemoveFromParent();
+				LocalPlayerInfoWidget = nullptr;
+
+				if (SharedInfoWidget) // Remove Widget of Shared info between players
+				{
+					if (SharedInfoWidget->IsInViewport()) 
+					{
+						SharedInfoWidget->RemoveFromParent();
+						SharedInfoWidget = nullptr;
+					}
+				}
 			}
 
+			// Add to Player Screen the Game Over widget
 			if(!GameOverWidget)
 			{
 				GameOverWidget = CreateWidget(this, GameOverWidgetClass);

--- a/Source/Cyber/Core/CyberPlayerController.h
+++ b/Source/Cyber/Core/CyberPlayerController.h
@@ -19,6 +19,10 @@ class CYBER_API ACyberPlayerController : public APlayerController
 	
 protected:
 
+	/* DEBUG */
+	UPROPERTY(EditAnywhere)
+	bool IsLocalMatch = false;
+
 	ACyberPlayerController();
 	UFUNCTION()
 	void ApplyStun(bool Apply);
@@ -29,12 +33,21 @@ protected:
 
 	virtual void OnRep_PlayerState() override;
 
-	/* Timer Elements */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Widget | Timer")
-	TSubclassOf<UUserWidget> PlayerInfoWidgetClass;
+	/* Local Multiplayer Widgets */
 
 	UPROPERTY()
-	UUserWidget* PlayerInfoWidget = nullptr;
+	UUserWidget* LocalPlayerInfoWidget = nullptr;
+
+	UPROPERTY()
+	UUserWidget* SharedInfoWidget = nullptr;
+
+	/* Online Multiplayer Widgets */
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Widget | Online Multiplayer")
+	TSubclassOf<UUserWidget> OnlinePlayerInfoWidgetClass;
+
+	UPROPERTY()
+	UUserWidget* OnlinePlayerInfoWidget = nullptr;
 
 	/* Indicator for Other Player position */
 

--- a/Source/Cyber/Core/CyberPlayerState.cpp
+++ b/Source/Cyber/Core/CyberPlayerState.cpp
@@ -35,6 +35,15 @@ void ACyberPlayerState::ResetPlayerDeathState(bool isCharacterDead)
     bIsCharacterDead = isCharacterDead;
 }
 
+void ACyberPlayerState::BindSaveLoadGameDelegates()
+{
+    if (UCyberGameInstance* CyberGameInstance = Cast<UCyberGameInstance>(GetGameInstance()))
+    {
+        CyberGameInstance->OnGameLoaded.AddDynamic(this, &ThisClass::OnGameLoadedEvent);
+        CyberGameInstance->OnGameSaved.AddDynamic(this, &ThisClass::OnGameSavedEvent);
+    }
+}
+
 void ACyberPlayerState::BeginPlay()
 {
     Super::BeginPlay();
@@ -43,12 +52,6 @@ void ACyberPlayerState::BeginPlay()
     if (ACyberGameState* CyberGameState = Cast<ACyberGameState>(UGameplayStatics::GetGameState(GetWorld())))
     {
         CyberGameState->ApplyEffectOnAllPlayers.AddDynamic(this, &ThisClass::ApplyGameplayEffectPlayerStateFromDelegate);
-    }
-
-    if (UCyberGameInstance* CyberGameInstance = Cast<UCyberGameInstance>(GetGameInstance()))
-    {
-        CyberGameInstance->OnGameLoaded.AddDynamic(this, &ThisClass::OnGameLoadedEvent);
-        CyberGameInstance->OnGameSaved.AddDynamic(this, &ThisClass::OnGameSavedEvent);
     }
 }
 

--- a/Source/Cyber/Core/CyberPlayerState.h
+++ b/Source/Cyber/Core/CyberPlayerState.h
@@ -55,6 +55,9 @@ public:
 	UFUNCTION(BlueprintCallable)
 	void ResetPlayerDeathState(bool isCharacterDead);
 
+	/* Game Save/Load Elements */
+	void BindSaveLoadGameDelegates();
+
 protected:
 
 	virtual void BeginPlay() override;


### PR DESCRIPTION
[ADD] Add Local Match option to menu.
Add GameViewportLocalMultiplayer (this plugin fixes a bug in this version of the engine only) Assign gamepad to second player (WIP)

Move Plugin to a subfolder up to prevent "max 260 characters path" error

Create Game Mode for Local Multiplayer (only used in Lobby_Local map)

Create Enum for Local Multiplayer in CyberStructs and include dependencies in Build.cs

Include AddMappingContext in PossessedBy method (only on BeginPlay makes Local Multiplayer not work)

[EDIT] Put local match outside of login in main menu

[EDIT] Add widgets to player screen instead of viewport

Set "Constraint Aspect Ratio" to false on Character camera and replace AddToViewport for AddToPlayerScreen on game over screens

[FIX] Solve problem with many players being created in local match each time the player plays again from menu

[EDIT] Componentization of in-game UI
Player health
Player Abilities

[MOD] Make PowerUps Menu navigable for controller

[MOD] Make UI modular for Local Matches

[FIX] Back button now adds Widget to Player Screen instead of Viewport

[FIX] Save Game implementation fixed for Local Multiplayer

[FIX] Fix Second Player UI not being removed neither refreshed after Game Over

[FIX] Focus on Back Button on Tutorial Widget

[MOD] Optimise buttons structuring in Main Menu

[FIX] Fix Hovered Text in Local Multiplayer

[DEL] Remove Unused functions after Fix Hovered Text for Local Multiplayer